### PR TITLE
Added quick escape functionality to UI's using backspace

### DIFF
--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -4,7 +4,12 @@
  * @license MIT
  */
 
-import { KEY_ENTER, KEY_ESCAPE, KEY_SPACE } from 'common/keycodes';
+import {
+  KEY_ENTER,
+  KEY_ESCAPE,
+  KEY_SPACE,
+  KEY_BACKSPACE,
+} from 'common/keycodes';
 import { classes, pureComponentHooks } from 'common/react';
 import { Component, createRef } from 'inferno';
 import { createLogger } from '../logging';
@@ -96,6 +101,11 @@ export const Button = (props) => {
         // Refocus layout on pressing escape.
         if (keyCode === KEY_ESCAPE) {
           e.preventDefault();
+          return;
+        }
+
+        if (keyCode === KEY_BACKSPACE) {
+          window.close(); // Closes the currently opened window
           return;
         }
       }}

--- a/tgui/packages/tgui/layouts/Window.js
+++ b/tgui/packages/tgui/layouts/Window.js
@@ -13,7 +13,12 @@ import { Icon } from '../components';
 import { UI_DISABLED, UI_INTERACTIVE, UI_UPDATE } from '../constants';
 import { useDebug } from '../debug';
 import { toggleKitchenSink } from '../debug/actions';
-import { dragStartHandler, recallWindowGeometry, resizeStartHandler, setWindowKey } from '../drag';
+import {
+  dragStartHandler,
+  recallWindowGeometry,
+  resizeStartHandler,
+  setWindowKey,
+} from '../drag';
 import { createLogger } from '../logging';
 import { Layout } from './Layout';
 


### PR DESCRIPTION
## About The Pull Request

Adds the ability to quickly exit a UI by pressing backspace. Previously, the only way to exit a UI was by clicking the 'x' button on the window

## Why It's Good For The Game

Lets players quickly close UI windows when they are in danger or in a rush

## Changelog

:cl:

qol: Can hit backspace in a UI to quickly exit it

/:cl:
